### PR TITLE
Upgraded OCI builds from GCC 13 to 14

### DIFF
--- a/tao.xml
+++ b/tao.xml
@@ -24,8 +24,8 @@ This is the TAO scoreboard. It shows all the OS/platform combinations on which
     <diffroot>https://github.com/DOCGroup/ACE_TAO/commit/</diffroot>
     </build>
   <build>
-    <name>Ubuntu_22_04_GCC13_x64_Debug</name>
-    <url>https://storage.googleapis.com/oci-scoreboard/ACE_TAO_Ubuntu_22_04_GCC13_x64_Debug</url>
+    <name>Ubuntu_22_04_GCC14_x64_Debug</name>
+    <url>https://storage.googleapis.com/oci-scoreboard/ACE_TAO_Ubuntu_22_04_GCC14_x64_Debug</url>
     <build_sponsor>OCI</build_sponsor>
     <build_sponsor_url>http://theaceorb.com/</build_sponsor_url>
     <diffroot>https://github.com/DOCGroup/ACE_TAO/commit/</diffroot>

--- a/tao2.xml
+++ b/tao2.xml
@@ -10,8 +10,8 @@ This is the TAO 2.5.x scoreboard. It shows all the OS/platform combinations on w
 <group>
   <name>Linux</name>
   <build>
-    <name>ACE6_TAO2_Ubuntu_22_04_GCC13_x64_Debug</name>
-    <url>https://storage.googleapis.com/oci-scoreboard/ACE6_TAO2_Ubuntu_22_04_GCC13_x64_Debug</url>
+    <name>ACE6_TAO2_Ubuntu_22_04_GCC14_x64_Debug</name>
+    <url>https://storage.googleapis.com/oci-scoreboard/ACE6_TAO2_Ubuntu_22_04_GCC14_x64_Debug</url>
     <build_sponsor>OCI</build_sponsor>
     <build_sponsor_url>http://theaceorb.com/</build_sponsor_url>
     <diffroot>https://github.com/DOCGroup/ACE_TAO/commit/</diffroot>


### PR DESCRIPTION
GCC 14 builds are configured with `-std=c++23`