### PR TITLE
Try to Fix Issues in ACE/TAO Scoreboard

### DIFF
--- a/naboo_dre.sh
+++ b/naboo_dre.sh
@@ -1,22 +1,35 @@
 #!/bin/bash
 
-set -ue
+set -u
 
-OUTPUT="${OUTPUT:-/export/web/www/scoreboard}"
-if ! [ -d "$OUTPUT" ]
+if [ -z ${SCOREBOARD_ROOT+defined} ]
 then
-    echo "\$OUTPUT directory ($OUTPUT) does not exist"
-    exit 1
+  this_script="${BASH_SOURCE[0]}"
+  export SCOREBOARD_ROOT=$( cd -- "$( dirname -- "$this_script" )" &> /dev/null && pwd )
+  cd "$SCOREBOARD_ROOT"
+  echo "Updating scoreboard at $SCOREBOARD_ROOT..."
+  git pull || exit 1
+  # Run this script in a new shell to make sure we're running the latest
+  # script.
+  exec "$this_script"
+else
+  echo "Updated scoreboard!"
 fi
 
-SCOREBOARD_ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd "$SCOREBOARD_ROOT"
-git pull
+OUTPUT="${OUTPUT:-/export/web/www/scoreboard}"
+echo "Output will be $OUTPUT"
+if ! [ -d "$OUTPUT" ]
+then
+  echo "\$OUTPUT directory ($OUTPUT) does not exist"
+  exit 1
+fi
 
 AUTOBUILD_ROOT="${AUTOBUILD_ROOT:-$HOME/autobuild}"
 cd "$AUTOBUILD_ROOT"
-git pull
+echo "Updating autobuild at $AUTOBUILD_ROOT..."
+git pull || exit 1
 
+exit_status=0
 groups=(
   ace
   ace6
@@ -26,6 +39,11 @@ groups=(
 
 # Generate the index page!
 /usr/bin/perl ./scoreboard.pl -v -d "$OUTPUT" -i "$SCOREBOARD_ROOT/index.xml"
+if [ $? -gt 0 ]
+then
+  echo "STATUS ERROR: scoreboard.pl for index page returned $?" 1>&2
+  exit_status=1
+fi
 
 xml_files=()
 for group in ${groups[@]}
@@ -36,9 +54,19 @@ do
 
   # Generate the normal pages for this group
   /usr/bin/perl ./scoreboard.pl -b -d "$OUTPUT" -f "$xml_file" -o "$group.html" -v
+  if [ $? -gt 0 ]
+  then
+    echo "STATUS ERROR: scoreboard.pl for $group pages returned $?" 1>&2
+    exit_status=1
+  fi
 
   # Generate the text matrix pages for this group
   ./matrix.py "${OUTPUT}"
+  if [ $? -gt 0 ]
+  then
+    echo "STATUS ERROR: matrix.py for $group returned $?" 1>&2
+    exit_status=1
+  fi
 
   # Remove the builds.json for this group
   rm "$OUTPUT/builds.json"
@@ -54,3 +82,10 @@ function join_by {
   fi
 }
 /usr/bin/perl ./scoreboard.pl -b -d "$OUTPUT" -z -j "$(join_by , ${xml_files[@]})"
+if [ $? -gt 0 ]
+then
+  echo "STATUS ERROR: scoreboard.pl for integrated pages returned $?" 1>&2
+  exit_status=1
+fi
+
+exit $exit_status


### PR DESCRIPTION
See https://github.com/DOCGroup/scoreboard/pull/8.

These changes try to make the script more robust by not always exiting on error immediately and rerunning itself after an update.